### PR TITLE
Refactor/extract external libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - platformio update
 
 script:
-  - platformio ci --lib="./src" -c platformio.ini ./examples/simple/
+  - platformio ci -c platformio.ini --lib="./src" --lib="./lib/*" ./examples/simple/
 
 notifications:
   email:

--- a/lib/ConfigParameter/BaseParameter.h
+++ b/lib/ConfigParameter/BaseParameter.h
@@ -1,0 +1,18 @@
+#ifndef __BASE_PARAMETER_H__
+#define __BASE_PARAMETER_H__
+
+enum Mode {ap, api};
+enum ParameterMode { get, set, both};
+
+/**
+ * Base Parameter
+ */
+class BaseParameter {
+public:
+    virtual ParameterMode getMode() = 0;
+    virtual void fromJson(JsonObject *json) = 0;
+    virtual void toJson(JsonObject *json) = 0;
+    virtual void clearData() = 0;
+};
+
+#endif /* __BASE_PARAMETER_H__ */

--- a/lib/ConfigParameter/BaseParameter.h
+++ b/lib/ConfigParameter/BaseParameter.h
@@ -4,7 +4,6 @@
 #include <ArduinoJson.h>
 #include <DebugPrint.h>
 
-enum Mode {ap, api};
 enum ParameterMode { get, set, both};
 
 /**

--- a/lib/ConfigParameter/BaseParameter.h
+++ b/lib/ConfigParameter/BaseParameter.h
@@ -1,6 +1,8 @@
 #ifndef __BASE_PARAMETER_H__
 #define __BASE_PARAMETER_H__
 
+#include <DebugPrint.h>
+
 enum Mode {ap, api};
 enum ParameterMode { get, set, both};
 

--- a/lib/ConfigParameter/BaseParameter.h
+++ b/lib/ConfigParameter/BaseParameter.h
@@ -1,6 +1,7 @@
 #ifndef __BASE_PARAMETER_H__
 #define __BASE_PARAMETER_H__
 
+#include <ArduinoJson.h>
 #include <DebugPrint.h>
 
 enum Mode {ap, api};

--- a/lib/ConfigParameter/ConfigParameter.h
+++ b/lib/ConfigParameter/ConfigParameter.h
@@ -1,0 +1,45 @@
+#ifndef __CONFIG_PARAMETER_H__
+#define __CONFIG_PARAMETER_H_
+
+#include "BaseParameter.h"
+
+/**
+ * Config Parameter
+ */
+template<typename T>
+class ConfigParameter : public BaseParameter {
+public:
+    ConfigParameter(const char *name, T *ptr, ParameterMode mode = both) {
+        this->name = name;
+        this->ptr = ptr;
+        this->mode = mode;
+    }
+
+    ParameterMode getMode() {
+        return this->mode;
+    }
+
+    void fromJson(JsonObject *json) {
+        if (json->containsKey(name) && json->is<T>(name)) {
+            *ptr = json->get<T>(name);
+        }
+    }
+
+    void toJson(JsonObject *json) {
+        json->set(name, *ptr);
+    }
+
+    void clearData() {
+        DebugPrint("Clearing: ");
+        DebugPrintln(name);
+        *ptr = T();
+    }
+
+private:
+    const char *name;
+    T *ptr;
+    std::function<void(const char*)> cb;
+    ParameterMode mode;
+};
+
+#endif /* __CONFIG_PARAMETER_H__ */

--- a/lib/ConfigParameter/ConfigParameter.h
+++ b/lib/ConfigParameter/ConfigParameter.h
@@ -1,7 +1,7 @@
 #ifndef __CONFIG_PARAMETER_H__
 #define __CONFIG_PARAMETER_H_
 
-#include "BaseParameter.h"
+#include <BaseParameter.h>
 
 /**
  * Config Parameter

--- a/lib/ConfigParameter/ConfigParameter.h
+++ b/lib/ConfigParameter/ConfigParameter.h
@@ -38,7 +38,6 @@ public:
 private:
     const char *name;
     T *ptr;
-    std::function<void(const char*)> cb;
     ParameterMode mode;
 };
 

--- a/lib/ConfigParameter/ConfigParameter.h
+++ b/lib/ConfigParameter/ConfigParameter.h
@@ -1,5 +1,5 @@
 #ifndef __CONFIG_PARAMETER_H__
-#define __CONFIG_PARAMETER_H_
+#define __CONFIG_PARAMETER_H__
 
 #include <BaseParameter.h>
 

--- a/lib/ConfigParameter/ConfigStringParameter.h
+++ b/lib/ConfigParameter/ConfigStringParameter.h
@@ -1,0 +1,50 @@
+#ifndef CONFIG_STRING_PARAMETER_H__
+#define __CONFIG_STRING_PARAMETER_H__
+
+#include "BaseParameter.h"
+
+/**
+ * Config String Parameter
+ */
+class ConfigStringParameter : public BaseParameter {
+public:
+    ConfigStringParameter(const char *name, char *ptr, size_t length, ParameterMode mode = both) {
+        this->name = name;
+        this->ptr = ptr;
+        this->length = length;
+        this->mode = mode;
+    }
+
+    ParameterMode getMode() {
+        return this->mode;
+    }
+
+    void fromJson(JsonObject *json) {
+        if (json->containsKey(name) && json->is<char *>(name)) {
+            const char * value = json->get<const char *>(name);
+
+            memset(ptr, NULL, length);
+            strncpy(ptr, const_cast<char*>(value), length - 1);
+        }
+    }
+
+    void toJson(JsonObject *json) {
+        json->set(name, ptr);
+    }
+
+    void clearData() {
+        DebugPrint("Clearing: ");
+        DebugPrintln(name);
+        memset(ptr, NULL, length);
+    }
+    
+
+private:
+    const char *name;
+    char *ptr;
+    size_t length;
+    ParameterMode mode;
+};
+
+
+#endif /* __CONFIG_STRING_PARAMETER_H__ */

--- a/lib/ConfigParameter/ConfigStringParameter.h
+++ b/lib/ConfigParameter/ConfigStringParameter.h
@@ -1,7 +1,7 @@
 #ifndef CONFIG_STRING_PARAMETER_H__
 #define __CONFIG_STRING_PARAMETER_H__
 
-#include "BaseParameter.h"
+#include <BaseParameter.h>
 
 /**
  * Config String Parameter

--- a/lib/ConfigParameter/ConfigStringParameter.h
+++ b/lib/ConfigParameter/ConfigStringParameter.h
@@ -1,4 +1,4 @@
-#ifndef CONFIG_STRING_PARAMETER_H__
+#ifndef __CONFIG_STRING_PARAMETER_H__
 #define __CONFIG_STRING_PARAMETER_H__
 
 #include <BaseParameter.h>

--- a/lib/DebugPrint/DebugPrint.h
+++ b/lib/DebugPrint/DebugPrint.h
@@ -1,0 +1,9 @@
+#ifndef __DEBUG_PRINT_H__
+#define __DEBUG_PRINT_H__
+
+extern bool DEBUG_MODE;
+
+#define DebugPrintln(a) (DEBUG_MODE ? Serial.println(a) : false)
+#define DebugPrint(a) (DEBUG_MODE ? Serial.print(a) : false)
+
+#endif /* __DEBUG_PRINT_H__ */

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -24,7 +24,6 @@
     #define WIFI_OPEN  WIFI_AUTH_OPEN
 #endif
 
-#include "DebugPrint.h"
 #include "ConfigParameter.h"
 #include "ConfigStringParameter.h"
 

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -42,6 +42,8 @@ extern const char mimePlain[];
 extern const char mimeCSS[];
 extern const char mimeJS[];
 
+enum Mode {ap, api};
+
 /**
  * Config Manager
  */

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -24,6 +24,10 @@
     #define WIFI_OPEN  WIFI_AUTH_OPEN
 #endif
 
+#include "DebugPrint.h"
+#include "ConfigParameter.h"
+#include "ConfigStringParameter.h"
+
 #define MAGIC_LENGTH 2
 #define SSID_LENGTH 32
 #define PASSWORD_LENGTH 64
@@ -33,112 +37,11 @@
     using WebServer = ESP8266WebServer;
 #endif
 
-extern bool DEBUG_MODE;
-
-#define DebugPrintln(a) (DEBUG_MODE ? Serial.println(a) : false)
-#define DebugPrint(a) (DEBUG_MODE ? Serial.print(a) : false)
-
 extern const char mimeHTML[];
 extern const char mimeJSON[];
 extern const char mimePlain[];
 extern const char mimeCSS[];
 extern const char mimeJS[];
-
-enum Mode {ap, api};
-enum ParameterMode { get, set, both};
-
-/**
- * Base Parameter
- */
-class BaseParameter {
-public:
-    virtual ParameterMode getMode() = 0;
-    virtual void fromJson(JsonObject *json) = 0;
-    virtual void toJson(JsonObject *json) = 0;
-    virtual void clearData() = 0;
-};
-
-/**
- * Config Parameter
- */
-template<typename T>
-class ConfigParameter : public BaseParameter {
-public:
-    ConfigParameter(const char *name, T *ptr, ParameterMode mode = both) {
-        this->name = name;
-        this->ptr = ptr;
-        this->mode = mode;
-    }
-
-    ParameterMode getMode() {
-        return this->mode;
-    }
-
-    void fromJson(JsonObject *json) {
-        if (json->containsKey(name) && json->is<T>(name)) {
-            *ptr = json->get<T>(name);
-        }
-    }
-
-    void toJson(JsonObject *json) {
-        json->set(name, *ptr);
-    }
-
-    void clearData() {
-        DebugPrint("Clearing: ");
-        DebugPrintln(name);
-        *ptr = T();
-    }
-
-private:
-    const char *name;
-    T *ptr;
-    std::function<void(const char*)> cb;
-    ParameterMode mode;
-};
-
-/**
- * Config String Parameter
- */
-class ConfigStringParameter : public BaseParameter {
-public:
-    ConfigStringParameter(const char *name, char *ptr, size_t length, ParameterMode mode = both) {
-        this->name = name;
-        this->ptr = ptr;
-        this->length = length;
-        this->mode = mode;
-    }
-
-    ParameterMode getMode() {
-        return this->mode;
-    }
-
-    void fromJson(JsonObject *json) {
-        if (json->containsKey(name) && json->is<char *>(name)) {
-            const char * value = json->get<const char *>(name);
-
-            memset(ptr, 0, length);
-            strncpy(ptr, const_cast<char*>(value), length - 1);
-        }
-    }
-
-    void toJson(JsonObject *json) {
-        json->set(name, ptr);
-    }
-
-    void clearData() {
-        DebugPrint("Clearing: ");
-        DebugPrintln(name);
-        memset(ptr, 0, length);
-    }
-
-
-private:
-    const char *name;
-    char *ptr;
-    size_t length;
-    ParameterMode mode;
-};
 
 /**
  * Config Manager

--- a/test/embedded/ConfigParameterTest.h
+++ b/test/embedded/ConfigParameterTest.h
@@ -7,8 +7,59 @@ bool DEBUG_MODE = false;
 
 void test_sets_config_parameter_mode() {
   const char *variable = "baphled";
+  ConfigParameter<const char*> parameter = ConfigParameter<const char*>("username", &variable, both);
 
-  ConfigParameter<const char*> configParameters = ConfigParameter<const char*>("username", &variable, both);
+  TEST_ASSERT_EQUAL(both, parameter.getMode());
+}
 
-  TEST_ASSERT_EQUAL(configParameters.getMode(), both);
+void test_config_parameter_stored_as_json() {
+  const char *variable = "baphled";
+  const char *expected = "{\"username\":\"baphled\"}";
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& obj = jsonBuffer.createObject();
+
+  char body[50] = "\n";
+
+  ConfigParameter<const char*> parameter = ConfigParameter<const char*>("username", &variable, get);
+
+  parameter.toJson(&obj);
+  obj.printTo(body);
+
+  TEST_ASSERT_EQUAL_STRING(expected, body);
+}
+
+void test_config_parameter_stored_from_json() {
+  const char *variable = "foo";
+  const char *expected = "{\"username\":\"baphled\"}";
+  char body[50] = "\n";
+
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& obj = jsonBuffer.parseObject(expected);
+
+  ConfigParameter<const char*> parameter = ConfigParameter<const char*>("username", &variable, set);
+
+  parameter.fromJson(&obj);
+
+  parameter.toJson(&obj);
+  obj.printTo(body);
+
+  TEST_ASSERT_EQUAL_STRING(expected, body);
+}
+
+void test_config_parameter_clear_data() {
+  const char *variable = "foo";
+  const char *expected = "{\"username\":null}";
+  char body[50] = "\n";
+
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& obj = jsonBuffer.createObject();
+
+  ConfigParameter<const char*> parameter = ConfigParameter<const char*>("username", &variable, set);
+
+  parameter.clearData();
+
+  parameter.toJson(&obj);
+  obj.printTo(body);
+
+  TEST_ASSERT_EQUAL_STRING(expected, body);
 }

--- a/test/embedded/ConfigParameterTest.h
+++ b/test/embedded/ConfigParameterTest.h
@@ -1,0 +1,14 @@
+#include <unity.h>
+
+#include <stdio.h>
+#include <ConfigParameter.h>
+
+bool DEBUG_MODE = false;
+
+void test_sets_config_parameter_mode() {
+  const char *variable = "baphled";
+
+  ConfigParameter<const char*> configParameters = ConfigParameter<const char*>("username", &variable, both);
+
+  TEST_ASSERT_EQUAL(configParameters.getMode(), both);
+}

--- a/test/embedded/ConfigParameterTest.h
+++ b/test/embedded/ConfigParameterTest.h
@@ -3,8 +3,6 @@
 #include <stdio.h>
 #include <ConfigParameter.h>
 
-bool DEBUG_MODE = false;
-
 void test_sets_config_parameter_mode() {
   const char *variable = "baphled";
   ConfigParameter<const char*> parameter = ConfigParameter<const char*>("username", &variable, both);

--- a/test/embedded/ConfigStringParameterTest.h
+++ b/test/embedded/ConfigStringParameterTest.h
@@ -1,0 +1,67 @@
+#include <unity.h>
+
+#include <stdio.h>
+#include <ConfigStringParameter.h>
+
+void test_sets_config_string_parameter_mode() {
+  char *variable = "baphled";
+  size_t length = 10;
+  ConfigStringParameter parameter = ConfigStringParameter("username", variable, length, both);
+
+  TEST_ASSERT_EQUAL(both, parameter.getMode());
+}
+
+void test_config_string_parameter_stored_as_json() {
+  char *variable = "baphled";
+  const char *expected = "{\"username\":\"baphled\"}";
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& obj = jsonBuffer.createObject();
+
+  char body[50] = "\n";
+  size_t length = 10;
+
+  ConfigStringParameter parameter = ConfigStringParameter("username", variable, length, set);
+
+  parameter.toJson(&obj);
+  obj.printTo(body);
+
+  TEST_ASSERT_EQUAL_STRING(expected, body);
+}
+
+void test_config_string_parameter_stored_from_json() {
+  char *variable = "foo";
+  const char *expected = "{\"username\":\"baphled\"}";
+  char body[50] = "\n";
+  size_t length = 10;
+
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& obj = jsonBuffer.parseObject(expected);
+
+  ConfigStringParameter parameter = ConfigStringParameter("username", variable, length, set);
+
+  parameter.fromJson(&obj);
+
+  parameter.toJson(&obj);
+  obj.printTo(body);
+
+  TEST_ASSERT_EQUAL_STRING(expected, body);
+}
+
+void test_config_string_parameter_clear_data() {
+  char *variable = "foo";
+  const char *expected = "{\"username\":\"\"}";
+  char body[50] = "\n";
+  size_t length = 10;
+
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& obj = jsonBuffer.createObject();
+
+  ConfigStringParameter parameter = ConfigStringParameter("username", variable, length, set);
+
+  parameter.clearData();
+
+  parameter.toJson(&obj);
+  obj.printTo(body);
+
+  TEST_ASSERT_EQUAL_STRING(expected, body);
+}

--- a/test/embedded/main.cpp
+++ b/test/embedded/main.cpp
@@ -6,8 +6,11 @@
 #include "ConfigParameterTest.h"
 #include "ConfigStringParameterTest.h"
 
+bool DEBUG_MODE = false;
+
 void setup() {
   delay(2000);
+
   UNITY_BEGIN();
 
   // ConfigParameterTest

--- a/test/embedded/main.cpp
+++ b/test/embedded/main.cpp
@@ -1,0 +1,18 @@
+#if defined(ARDUINO) && defined(UNIT_TEST)
+#include "Arduino.h"
+
+#include <unity.h>
+
+#include "ConfigParameterTest.h"
+
+void setup() {
+  delay(2000);
+  UNITY_BEGIN();
+
+  RUN_TEST(test_sets_config_parameter_mode);
+
+  UNITY_END();
+}
+
+void loop() {}
+#endif

--- a/test/embedded/main.cpp
+++ b/test/embedded/main.cpp
@@ -10,6 +10,9 @@ void setup() {
   UNITY_BEGIN();
 
   RUN_TEST(test_sets_config_parameter_mode);
+  RUN_TEST(test_config_parameter_stored_as_json);
+  RUN_TEST(test_config_parameter_stored_from_json);
+  RUN_TEST(test_config_parameter_clear_data);
 
   UNITY_END();
 }

--- a/test/embedded/main.cpp
+++ b/test/embedded/main.cpp
@@ -4,15 +4,23 @@
 #include <unity.h>
 
 #include "ConfigParameterTest.h"
+#include "ConfigStringParameterTest.h"
 
 void setup() {
   delay(2000);
   UNITY_BEGIN();
 
+  // ConfigParameterTest
   RUN_TEST(test_sets_config_parameter_mode);
   RUN_TEST(test_config_parameter_stored_as_json);
   RUN_TEST(test_config_parameter_stored_from_json);
   RUN_TEST(test_config_parameter_clear_data);
+
+  // ConfigStringParameterTest
+  RUN_TEST(test_sets_config_string_parameter_mode);
+  RUN_TEST(test_config_string_parameter_stored_as_json);
+  RUN_TEST(test_config_string_parameter_stored_from_json);
+  RUN_TEST(test_config_string_parameter_clear_data);
 
   UNITY_END();
 }


### PR DESCRIPTION
This PR addresses the fact that there are a few classes tucked away inside `ConfigManager.h`.

It moves `BaseParameter`, and it's associated classes, into their own header file. As well as moving the debugging definitions into their own file.

This also functions as POC for using the `lib` directory for classes that aren't directly used by users of the library but required by `ConfigManager` itself.

We also introduce a few unit tests to help drive some of the changes.

At present these tests require a ESP8266 and ESP32 board to run the tests against. This is due to the requirement of the Arduino library when it comes to using `ArduinoJson`.

This could be changed to running the tests natively, once `ArduinoJson` is replaced with a JSON library that is not reliant on `Arduino.h` header file.

Swapping out `ArduinoJson` will allow us to run our tests natively, allowing for our tests to run quicker and not require any boards to run the tests against.

We could still use the current setup, so that we can test `ConfigManager` against real boards, so this seems like a sane step to make to get the library under test.